### PR TITLE
Create hacs.json

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-  "name": "FlashForge Adventurer 3",
+  "name": "FlashForge Adventurer 5",
   "render_readme": true,
   "homeassistant": "2022.6",
   "hacs": "1.26"

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,6 @@
+{
+  "name": "FlashForge Adventurer 3",
+  "render_readme": true,
+  "homeassistant": "2022.6",
+  "hacs": "1.26"
+}


### PR DESCRIPTION
New versions of home assistant do not install the module if hacs.json file is not in the repository.